### PR TITLE
Fix param sync to keep user-added params

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -163,15 +163,12 @@ export default function App() {
             changed = true;
           }
         });
-        const filtered = params.filter((p) => names.includes(p.name) || p.value);
-        if (filtered.length !== params.length) {
-          params = filtered;
-          changed = true;
-        }
+        // Preserve parameters even if not present in the XSLT so users can add
+        // new ones via the UI. Only add missing parameters from the stylesheet.
         return changed ? { ...t, params } : t;
       }),
     );
-  }, [activeTab.xslt]);
+  }, [active, activeTab.xslt]);
 
   const updateParam = (index, field, value) => {
     setTabs((tabs) =>


### PR DESCRIPTION
## Summary
- preserve parameters that don't exist in the current XSLT so they persist after a new stylesheet is loaded

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6864e55ef03c832980e2b58ffed42238