### PR TITLE
Add Helm chart for Kubernetes deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,20 @@ The compose file builds the frontend with `VITE_BACKEND_URL=http://backend:8000`
 so it talks to the backend container.
 
 This starts the backend on port `8000`, the frontend on `3000` and a PostgreSQL instance on `5432`.
+
+## Helm Chart
+
+A Helm chart is provided under `charts/xslt-playground` to deploy the frontend and backend on Kubernetes. Before installing, create a secret with your Firebase credentials:
+
+```bash
+kubectl create secret generic firebase-config \
+  --from-file=service-account.json=</path/to/serviceAccount.json> \
+  --from-file=firebase-config.json=</path/to/firebaseConfig.json>
+```
+
+Install the chart with:
+
+```bash
+helm install xslt charts/xslt-playground
+```
+

--- a/charts/xslt-playground/Chart.yaml
+++ b/charts/xslt-playground/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: xslt-playground
+description: Helm chart for xslt-playground frontend and backend
+version: 0.1.0
+appVersion: "0.1.0"
+

--- a/charts/xslt-playground/README.md
+++ b/charts/xslt-playground/README.md
@@ -1,0 +1,32 @@
+# xslt-playground Helm Chart
+
+This chart deploys the frontend and backend of xslt-playground.
+
+## Configuration
+
+Key parameters in `values.yaml`:
+
+- `image.frontend` and `image.backend` – container images.
+- `firebaseSecretName` – name of the secret containing Firebase credentials.
+  - `firebase.credentialsKey` is mounted for the backend and referenced by
+    `GOOGLE_APPLICATION_CREDENTIALS`.
+  - `firebase.configKey` is used for the `VITE_FIREBASE_CONFIG` environment
+    variable of the frontend.
+- `databaseUrl` – connection string used by the backend.
+- `ingress` – configure ingress for the frontend service.
+- `hpa` – enable CPU-based autoscaling for both deployments.
+
+Create the secret before installing the chart:
+
+```bash
+kubectl create secret generic firebase-config \
+  --from-file=service-account.json=</path/to/serviceAccount.json> \
+  --from-file=firebase-config.json=</path/to/firebaseConfig.json>
+```
+
+Install the chart with:
+
+```bash
+helm install xslt charts/xslt-playground
+```
+

--- a/charts/xslt-playground/templates/_helpers.tpl
+++ b/charts/xslt-playground/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{- define "xslt-playground.labels" }}
+app.kubernetes.io/name: {{ .Chart.Name }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+{{- define "xslt-playground.selectorLabels" }}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+{{- define "xslt-playground.fullname" }}
+{{- printf "%s-%s" .Release.Name .Chart.Name }}
+{{- end }}
+

--- a/charts/xslt-playground/templates/backend-deployment.yaml
+++ b/charts/xslt-playground/templates/backend-deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "xslt-playground.fullname" . }}-backend
+  labels:
+    {{- include "xslt-playground.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount.backend }}
+  selector:
+    matchLabels:
+      {{- include "xslt-playground.selectorLabels" . | nindent 6 }}
+      component: backend
+  template:
+    metadata:
+      labels:
+        {{- include "xslt-playground.selectorLabels" . | nindent 8 }}
+        component: backend
+    spec:
+      containers:
+        - name: backend
+          image: "{{ .Values.image.backend.repository }}:{{ .Values.image.backend.tag }}"
+          imagePullPolicy: {{ .Values.image.backend.pullPolicy }}
+          env:
+            - name: DATABASE_URL
+              value: {{ .Values.databaseUrl | quote }}
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              value: {{ printf "%s/%s" .Values.firebase.credentialsMountPath .Values.firebase.credentialsKey | quote }}
+          volumeMounts:
+            - name: firebase
+              mountPath: {{ .Values.firebase.credentialsMountPath }}
+              readOnly: true
+          ports:
+            - containerPort: {{ .Values.service.backend.port }}
+      volumes:
+        - name: firebase
+          secret:
+            secretName: {{ .Values.firebaseSecretName }}
+            items:
+              - key: {{ .Values.firebase.credentialsKey }}
+                path: {{ .Values.firebase.credentialsKey }}
+

--- a/charts/xslt-playground/templates/backend-hpa.yaml
+++ b/charts/xslt-playground/templates/backend-hpa.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.hpa.backend.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "xslt-playground.fullname" . }}-backend
+  labels:
+    {{- include "xslt-playground.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "xslt-playground.fullname" . }}-backend
+  minReplicas: {{ .Values.hpa.backend.minReplicas }}
+  maxReplicas: {{ .Values.hpa.backend.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.backend.targetCPUUtilizationPercentage }}
+{{- end }}
+

--- a/charts/xslt-playground/templates/backend-service.yaml
+++ b/charts/xslt-playground/templates/backend-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "xslt-playground.fullname" . }}-backend
+  labels:
+    {{- include "xslt-playground.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.backend.type }}
+  ports:
+    - port: {{ .Values.service.backend.port }}
+      targetPort: {{ .Values.service.backend.port }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "xslt-playground.selectorLabels" . | nindent 4 }}
+    component: backend
+

--- a/charts/xslt-playground/templates/frontend-deployment.yaml
+++ b/charts/xslt-playground/templates/frontend-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "xslt-playground.fullname" . }}-frontend
+  labels:
+    {{- include "xslt-playground.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount.frontend }}
+  selector:
+    matchLabels:
+      {{- include "xslt-playground.selectorLabels" . | nindent 6 }}
+      component: frontend
+  template:
+    metadata:
+      labels:
+        {{- include "xslt-playground.selectorLabels" . | nindent 8 }}
+        component: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: "{{ .Values.image.frontend.repository }}:{{ .Values.image.frontend.tag }}"
+          imagePullPolicy: {{ .Values.image.frontend.pullPolicy }}
+          env:
+            - name: VITE_BACKEND_URL
+              value: http://{{ include "xslt-playground.fullname" . }}-backend:{{ .Values.service.backend.port }}
+            - name: VITE_FIREBASE_CONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.firebaseSecretName }}
+                  key: {{ .Values.firebase.configKey }}
+          ports:
+            - containerPort: {{ .Values.service.frontend.port }}
+          resources: {{- toYaml .Values.resources.frontend | nindent 12 }}
+

--- a/charts/xslt-playground/templates/frontend-hpa.yaml
+++ b/charts/xslt-playground/templates/frontend-hpa.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.hpa.frontend.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "xslt-playground.fullname" . }}-frontend
+  labels:
+    {{- include "xslt-playground.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "xslt-playground.fullname" . }}-frontend
+  minReplicas: {{ .Values.hpa.frontend.minReplicas }}
+  maxReplicas: {{ .Values.hpa.frontend.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.frontend.targetCPUUtilizationPercentage }}
+{{- end }}
+

--- a/charts/xslt-playground/templates/frontend-ingress.yaml
+++ b/charts/xslt-playground/templates/frontend-ingress.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "xslt-playground.fullname" . }}-frontend
+  {{- with .Values.ingress.className }}
+  annotations:
+    kubernetes.io/ingress.class: {{ . | quote }}
+  {{- end }}
+  {{- range $k, $v := .Values.ingress.annotations }}
+    {{ $k }}: {{ $v | quote }}
+  {{- end }}
+  labels:
+    {{- include "xslt-playground.labels" $ | nindent 4 }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "xslt-playground.fullname" $ }}-frontend
+                port:
+                  number: {{ $.Values.service.frontend.port }}
+        {{- end }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . }}
+        {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+

--- a/charts/xslt-playground/templates/frontend-service.yaml
+++ b/charts/xslt-playground/templates/frontend-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "xslt-playground.fullname" . }}-frontend
+  labels:
+    {{- include "xslt-playground.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.frontend.type }}
+  ports:
+    - port: {{ .Values.service.frontend.port }}
+      targetPort: {{ .Values.service.frontend.port }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "xslt-playground.selectorLabels" . | nindent 4 }}
+    component: frontend
+

--- a/charts/xslt-playground/templates/secret.yaml
+++ b/charts/xslt-playground/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.firebaseSecretName }}
+  labels:
+    {{- include "xslt-playground.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ .Values.firebase.credentialsKey }}: {{ .Values.firebase.credentials | default "" | b64enc | quote }}
+  {{ .Values.firebase.configKey }}: {{ .Values.firebase.config | default "" | b64enc | quote }}
+

--- a/charts/xslt-playground/values.yaml
+++ b/charts/xslt-playground/values.yaml
@@ -1,0 +1,58 @@
+replicaCount:
+  frontend: 1
+  backend: 1
+
+image:
+  frontend:
+    repository: xslt-playground-frontend
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  backend:
+    repository: xslt-playground-backend
+    tag: "latest"
+    pullPolicy: IfNotPresent
+
+service:
+  frontend:
+    type: ClusterIP
+    port: 80
+  backend:
+    type: ClusterIP
+    port: 8000
+
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  hosts:
+    - host: xslt.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  frontend: {}
+  backend: {}
+
+hpa:
+  frontend:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 80
+  backend:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPUUtilizationPercentage: 80
+
+firebaseSecretName: firebase-config
+firebase:
+  credentialsKey: service-account.json
+  configKey: firebase-config.json
+  credentialsMountPath: /var/secrets/firebase
+
+# Example database URL
+databaseUrl: postgres://postgres:postgres@db/xslt?sslmode=disable
+


### PR DESCRIPTION
## Summary
- add `xslt-playground` Helm chart with deployments for frontend and backend
- configure Firebase credentials through a Kubernetes secret
- add HPA resources for both components
- expose the frontend via an ingress
- document the chart and how to use it

## Testing
- `go vet ./...` *(fails: Forbidden when fetching modules)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653cb088488329ab30b7903b161a19