### PR TITLE
Add dropdown for XSLT version and align file actions

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -39,8 +39,20 @@ body,
   font-weight: bold;
 }
 
-.toggle button {
+.toggle {
+  display: flex;
+  align-items: center;
+}
+
+.toggle button,
+.toggle select {
   margin-right: 0.25rem;
+}
+
+.toggle .right-actions {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
 }
 
 .error-box {


### PR DESCRIPTION
## Summary
- change version toggle to dropdown
- keep XSLT markup in sync when version changes
- align upload/download buttons to the right of the toggle section

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68653b545a9083298f62b9770835edb9