### PR TITLE
Add goPro mode to backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ its dependencies from `/opt/saxon/*`.
 
 ### Environment
 
-The backend requires a PostgreSQL database and Firebase credentials for
+When `VITE_GO_PRO=true` the backend stores transformation history and
+requires a PostgreSQL database as well as Firebase credentials for
 authentication. Provide these via environment variables:
 
 ```bash
@@ -69,6 +70,9 @@ export SAXON_CLASSPATH=/opt/saxon/*
 ```
 
 The Firebase project ID is read from the credentials file.
+
+If `VITE_GO_PRO` is not set or is `false` the backend skips database and
+Firebase initialization and only exposes the `/transform` endpoint.
 
 ### Makefile
 


### PR DESCRIPTION
## Summary
- enable non-pro mode in backend by checking `VITE_GO_PRO`
- only start Firebase & database if pro mode is enabled
- hide user history routes when not in pro mode
- document behaviour of `VITE_GO_PRO` in README

## Testing
- `go build -o ../server` *(fails: storage.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68677afacf4c8329bf72b788fac9f155