### PR TITLE
Publish images to GHCR

### DIFF
--- a/.github/workflows/publish-helm.yml
+++ b/.github/workflows/publish-helm.yml
@@ -1,0 +1,35 @@
+name: Publish Helm chart
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release-chart:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+
+      - name: Package chart
+        run: |
+          mkdir -p chart-output
+          helm package charts/xslt-playground -d chart-output
+
+      - name: Generate chart index
+        run: |
+          cd chart-output
+          helm repo index . --url "https://$GITHUB_REPOSITORY_OWNER.github.io/${GITHUB_REPOSITORY#*/}"
+
+      - name: Publish to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: chart-output

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,66 @@
+name: Publish Docker images
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/xslt-playground-backend:latest
+
+      - name: Make backend image public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGE: xslt-playground-backend
+        run: |
+          echo "$GH_TOKEN" | gh auth login --with-token
+          if gh api orgs/$OWNER > /dev/null 2>&1; then
+            gh api -X PATCH /orgs/$OWNER/packages/container/$PACKAGE --field visibility=public
+          else
+            gh api -X PATCH /user/packages/container/$PACKAGE --field visibility=public
+          fi
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/xslt-playground-frontend:latest
+
+      - name: Make frontend image public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          PACKAGE: xslt-playground-frontend
+        run: |
+          echo "$GH_TOKEN" | gh auth login --with-token
+          if gh api orgs/$OWNER > /dev/null 2>&1; then
+            gh api -X PATCH /orgs/$OWNER/packages/container/$PACKAGE --field visibility=public
+          else
+            gh api -X PATCH /user/packages/container/$PACKAGE --field visibility=public
+          fi


### PR DESCRIPTION
## Summary
- build backend and frontend container images using GitHub Actions
- push the images to GitHub Container Registry
- set package visibility to public after each push
- publish the Helm chart to `gh-pages` for external access

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6867845c1e2883298452a7e0787cc0a4