### PR TITLE
Add backend ingress

### DIFF
--- a/charts/xslt-playground/README.md
+++ b/charts/xslt-playground/README.md
@@ -15,7 +15,9 @@ Key parameters in `values.yaml`:
 - `storage.enabled` – disable database usage when `false`. If enabled the backend
   gets `DATABASE_URL` from `storage.databaseUrl`; otherwise the environment
   variable `DISABLE_DATABASE=true` is set.
-- `ingress` – configure ingress for the frontend service.
+- `ingress` – configure ingress for the frontend service. The backend is exposed
+  through a second ingress using the hostname `backend.<hostname>` with the same
+  settings.
 - `hpa` – enable CPU-based autoscaling for both deployments.
 
 When `firebase.enabled` is true you must create the secret before installing the chart:

--- a/charts/xslt-playground/templates/backend-ingress.yaml
+++ b/charts/xslt-playground/templates/backend-ingress.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "xslt-playground.fullname" . }}-backend
+  {{- with .Values.ingress.className }}
+  annotations:
+    kubernetes.io/ingress.class: {{ . | quote }}
+  {{- end }}
+  {{- range $k, $v := .Values.ingress.annotations }}
+    {{ $k }}: {{ $v | quote }}
+  {{- end }}
+  labels:
+    {{- include "xslt-playground.labels" $ | nindent 4 }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ printf "backend.%s" .host }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "xslt-playground.fullname" $ }}-backend
+                port:
+                  number: {{ $.Values.service.backend.port }}
+        {{- end }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ printf "backend.%s" . }}
+        {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary
- add a second ingress resource for the backend
- document new backend ingress in chart README

## Testing
- `apt-get install -y helm` *(fails: Unable to locate package helm)*
- `helm lint charts/xslt-playground` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68679ed433c483298defb302095eae07