### PR TITLE
Add configurable backend URL for frontend

### DIFF
--- a/charts/xslt-playground/Chart.yaml
+++ b/charts/xslt-playground/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: xslt-playground
 description: Helm chart for xslt-playground frontend and backend
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
 

--- a/charts/xslt-playground/README.md
+++ b/charts/xslt-playground/README.md
@@ -18,6 +18,8 @@ Key parameters in `values.yaml`:
 - `ingress` – configure ingress for the frontend service. The backend is exposed
   through a second ingress using the hostname `backend.<hostname>` with the same
   settings.
+- `frontend.backendUrl` – value for `VITE_BACKEND_URL` used by the frontend.
+  When empty it defaults to the internal backend service URL.
 - `hpa` – enable CPU-based autoscaling for both deployments.
 
 When `firebase.enabled` is true you must create the secret before installing the chart:

--- a/charts/xslt-playground/templates/frontend-deployment.yaml
+++ b/charts/xslt-playground/templates/frontend-deployment.yaml
@@ -22,7 +22,7 @@ spec:
           imagePullPolicy: {{ .Values.image.frontend.pullPolicy }}
           env:
             - name: VITE_BACKEND_URL
-              value: http://{{ include "xslt-playground.fullname" . }}-backend:{{ .Values.service.backend.port }}
+              value: {{ default (printf "http://%s-backend:%d" (include "xslt-playground.fullname" .) .Values.service.backend.port) .Values.frontend.backendUrl | quote }}
 {{- if .Values.firebase.enabled }}
             - name: VITE_FIREBASE_CONFIG
               valueFrom:

--- a/charts/xslt-playground/values.yaml
+++ b/charts/xslt-playground/values.yaml
@@ -58,3 +58,8 @@ storage:
   enabled: true
   databaseUrl: postgres://postgres:postgres@db/xslt?sslmode=disable
 
+frontend:
+  # URL used by the frontend to reach the backend. Defaults to the
+  # internal service URL when empty.
+  backendUrl: ""
+


### PR DESCRIPTION
## Summary
- allow configuring `VITE_BACKEND_URL` via `frontend.backendUrl`
- document new option
- bump chart version to 0.1.1

## Testing
- `helm lint charts/xslt-playground` *(fails: `helm` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6867a09cf4748329a4cdd093d2abebde