### PR TITLE
Add backend URL logging for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ docker build -t xslt-playground-frontend \
   --build-arg VITE_BACKEND_URL=http://localhost:8000 frontend
 ```
 
-The resulting image serves the static files with nginx on port 80.
+The resulting image serves the static files with nginx on port 80. When the
+container starts it logs the value of `VITE_BACKEND_URL` so you can confirm the
+backend in use in the pod logs:
+
+```
+Using this URL as backendURL: http://localhost:8000
+```
 
 ## Backend
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,5 +10,7 @@ RUN npm run build
 # Stage 2: serve the static files
 FROM nginx:alpine
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["/entrypoint.sh"]

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+# Print backend URL for debugging
+echo "Using this URL as backendURL: ${VITE_BACKEND_URL}"
+# Execute nginx as main process
+exec nginx -g 'daemon off;'

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -50,7 +50,6 @@ function injectParamBlock(text, params) {
 }
 
 function addParams(text, tab) {
-  console.log("AQUI!!!!")
   const extractedParams = extractParamNames(text);
   const existingNames = new Set(tab.params.map(p => p.name));
   const newParams = [...tab.params];
@@ -128,6 +127,7 @@ export default function App() {
   const [auth, setAuth] = useState(null);
 
   const backendBase = (import.meta.env.VITE_BACKEND_URL || "").replace(/\/$/, "");
+  console.log("Using this URL as backendURL:", backendBase);
 
   useEffect(() => {
     if (goPro) {


### PR DESCRIPTION
## Summary
- log the backend URL used by the frontend container at startup
- add entrypoint script for nginx
- update Dockerfile to call the new entrypoint
- remove leftover debug log and log backend URL in React app
- document backend URL logging in README

## Testing
- `npm install --prefix frontend`
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6867a58ec7848329a5e41489a68909d8