### PR TITLE
Enable runtime env vars for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,16 @@ npm run dev
 This starts the playground at `http://localhost:3000`.
 
 The app will call the Go backend at `/transform` to perform XSLT transformations.
-Set the backend URL by creating a `.env` file inside `frontend/`:
+Set the backend URL by creating a `.env` file inside `frontend/` or by exporting
+`VITE_BACKEND_URL` when starting the dev server:
 
 ```bash
-VITE_BACKEND_URL=http://localhost:8000
+VITE_BACKEND_URL=http://localhost:8000 npm run dev
 ```
 
-If omitted the app assumes the backend runs on the same host and port.
+If omitted the app assumes the backend runs on the same host and port. In the
+containerized version the URL is now read at **runtime** from environment
+variables so you can configure it directly in the pod.
 
 When `VITE_GO_PRO=true` the UI exposes additional features like Google
 authentication and multiple transformation tabs. For authentication you must
@@ -31,13 +34,13 @@ object used by `initializeApp`.
 To build a container with the compiled frontend run:
 
 ```bash
-docker build -t xslt-playground-frontend \
-  --build-arg VITE_BACKEND_URL=http://localhost:8000 frontend
+docker build -t xslt-playground-frontend frontend
 ```
 
 The resulting image serves the static files with nginx on port 80. When the
 container starts it logs the value of `VITE_BACKEND_URL` so you can confirm the
-backend in use in the pod logs:
+backend in use in the pod logs. The URL is now picked up **at runtime** from the
+container environment.
 
 ```
 Using this URL as backendURL: http://localhost:8000
@@ -114,8 +117,8 @@ docker compose -f docker-compose.local.yml up
 
 This starts just the frontend and backend with `VITE_GO_PRO=false`.
 
-The compose file builds the frontend with `VITE_BACKEND_URL=http://backend:8000`
-so it talks to the backend container.
+The compose file passes `VITE_BACKEND_URL=http://backend:8000` to the frontend
+container so it talks to the backend container.
 
 This starts the backend on port `8000`, the frontend on `3000` and a PostgreSQL instance on `5432`.
 

--- a/charts/xslt-playground/README.md
+++ b/charts/xslt-playground/README.md
@@ -18,8 +18,10 @@ Key parameters in `values.yaml`:
 - `ingress` – configure ingress for the frontend service. The backend is exposed
   through a second ingress using the hostname `backend.<hostname>` with the same
   settings.
-- `frontend.backendUrl` – value for `VITE_BACKEND_URL` used by the frontend.
-  When empty it defaults to the internal backend service URL.
+  - `frontend.backendUrl` – value for `VITE_BACKEND_URL` used by the frontend.
+    The frontend reads this variable at runtime so changing the deployment does
+    not require rebuilding the image. When empty it defaults to the internal
+    backend service URL.
 - `hpa` – enable CPU-based autoscaling for both deployments.
 
 When `firebase.enabled` is true you must create the secret before installing the chart:

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -1,6 +1,18 @@
 #!/bin/sh
 set -e
+# Write runtime environment variables for the frontend
+cat <<EOF >/usr/share/nginx/html/env.js
+window.env = {
+  VITE_BACKEND_URL: "${VITE_BACKEND_URL}",
+  VITE_GO_PRO: "${VITE_GO_PRO}",
+  VITE_ADSENSE_CLIENT: "${VITE_ADSENSE_CLIENT}",
+  VITE_ADSENSE_SLOT: "${VITE_ADSENSE_SLOT}",
+  VITE_FIREBASE_CONFIG: "${VITE_FIREBASE_CONFIG}"
+};
+EOF
+
 # Print backend URL for debugging
 echo "Using this URL as backendURL: ${VITE_BACKEND_URL}"
+
 # Execute nginx as main process
 exec nginx -g 'daemon off;'

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,11 +21,18 @@
     <meta property="og:url" content="https://xsltplayground.com/" />
     <meta property="og:image" content="/logo.svg" />
     <link rel="canonical" href="https://xsltplayground.com/" />
-    <script
-      async
-      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=%VITE_ADSENSE_CLIENT%"
-      crossorigin="anonymous"
-    ></script>
+    <script type="module" src="/env.js"></script>
+    <script>
+      if (window.env && window.env.VITE_ADSENSE_CLIENT) {
+        const s = document.createElement('script');
+        s.async = true;
+        s.src =
+          'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=' +
+          window.env.VITE_ADSENSE_CLIENT;
+        s.crossOrigin = 'anonymous';
+        document.head.appendChild(s);
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/env.js
+++ b/frontend/public/env.js
@@ -1,0 +1,1 @@
+window.env = {};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -95,9 +95,10 @@ function setStylesheetVersion(text, version) {
   return text.replace(regex, `<xsl:stylesheet${attrs}>`);
 }
 
-const goPro = import.meta.env.VITE_GO_PRO === "true";
-const adsenseClient = import.meta.env.VITE_ADSENSE_CLIENT;
-const adsenseSlot = import.meta.env.VITE_ADSENSE_SLOT;
+const env = window.env || import.meta.env;
+const goPro = env.VITE_GO_PRO === "true";
+const adsenseClient = env.VITE_ADSENSE_CLIENT;
+const adsenseSlot = env.VITE_ADSENSE_SLOT;
 
 function defaultTab() {
   return {
@@ -126,7 +127,7 @@ export default function App() {
   const [user, setUser] = useState(null);
   const [auth, setAuth] = useState(null);
 
-  const backendBase = (import.meta.env.VITE_BACKEND_URL || "").replace(/\/$/, "");
+  const backendBase = (env.VITE_BACKEND_URL || "").replace(/\/$/, "");
   console.log("Using this URL as backendURL:", backendBase);
 
   useEffect(() => {
@@ -138,7 +139,7 @@ export default function App() {
   useEffect(() => {
     if (!goPro) return;
     try {
-      const cfg = import.meta.env.VITE_FIREBASE_CONFIG;
+      const cfg = env.VITE_FIREBASE_CONFIG;
       if (cfg) {
         const app = initializeApp(JSON.parse(cfg));
         const a = getAuth(app);


### PR DESCRIPTION
## Summary
- load runtime environment variables in frontend
- generate env.js on container startup
- dynamically load adsense script
- document runtime configuration in README
- explain env variable usage in Helm README

## Testing
- `npm run build`
- `helm lint charts/xslt-playground` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b47d861c8329a56426110d9cd566