### PR TITLE
Add ads.txt support via Helm

### DIFF
--- a/charts/xslt-playground/Chart.yaml
+++ b/charts/xslt-playground/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: xslt-playground
 description: Helm chart for xslt-playground frontend and backend
-version: 0.1.1
+version: 0.1.2
 appVersion: "0.1.0"
 

--- a/charts/xslt-playground/README.md
+++ b/charts/xslt-playground/README.md
@@ -22,6 +22,7 @@ Key parameters in `values.yaml`:
     The frontend reads this variable at runtime so changing the deployment does
     not require rebuilding the image. When empty it defaults to the internal
     backend service URL.
+- `adsTxt` – optional content for an `ads.txt` file served by the frontend pod.
 - `hpa` – enable CPU-based autoscaling for both deployments.
 
 When `firebase.enabled` is true you must create the secret before installing the chart:

--- a/charts/xslt-playground/templates/ads-configmap.yaml
+++ b/charts/xslt-playground/templates/ads-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.adsTxt }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "xslt-playground.fullname" . }}-ads
+  labels:
+    {{- include "xslt-playground.labels" . | nindent 4 }}
+data:
+  ads.txt: |
+{{ .Values.adsTxt | indent 4 }}
+{{- end }}

--- a/charts/xslt-playground/templates/frontend-deployment.yaml
+++ b/charts/xslt-playground/templates/frontend-deployment.yaml
@@ -30,7 +30,23 @@ spec:
                   name: {{ .Values.firebase.secretName }}
                   key: {{ .Values.firebase.configKey }}
 {{- end }}
+{{- if .Values.adsTxt }}
+          volumeMounts:
+            - name: ads
+              mountPath: /usr/share/nginx/html/ads.txt
+              subPath: ads.txt
+              readOnly: true
+{{- end }}
           ports:
             - containerPort: {{ .Values.service.frontend.port }}
           resources: {{- toYaml .Values.resources.frontend | nindent 12 }}
+{{- if .Values.adsTxt }}
+      volumes:
+        - name: ads
+          configMap:
+            name: {{ include "xslt-playground.fullname" . }}-ads
+            items:
+              - key: ads.txt
+                path: ads.txt
+{{- end }}
 

--- a/charts/xslt-playground/values.yaml
+++ b/charts/xslt-playground/values.yaml
@@ -63,3 +63,6 @@ frontend:
   # internal service URL when empty.
   backendUrl: ""
 
+# Content for the optional ads.txt file served by the frontend
+adsTxt: ""
+


### PR DESCRIPTION
## Summary
- bump chart version to 0.1.2
- add new `adsTxt` value and ConfigMap
- mount optional `ads.txt` file in frontend deployment
- document new option in chart README

## Testing
- `apt-get update`
- `apt-get install -y helm` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6867be99dc98832995acde883e27a36d