### PR TITLE
Fix parameter quoting

### DIFF
--- a/backend/src/main.go
+++ b/backend/src/main.go
@@ -181,7 +181,7 @@ func main() {
 			"-o:" + outputPath,
 		}
 		for k, v := range req.Parameters {
-			cmdArgs = append(cmdArgs, k+"='"+v+"'")
+			cmdArgs = append(cmdArgs, k+"="+v)
 		}
 
 		cmd := exec.Command("java", cmdArgs...)


### PR DESCRIPTION
## Summary
- don't wrap parameter values in single quotes when invoking Saxon

## Testing
- `go build` *(fails: Forbidden errors fetching go modules)*

------
https://chatgpt.com/codex/tasks/task_e_68680bfa34dc8329a0b5c07e9ba724eb