### PR TITLE
Fix param cleanup in frontend

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,14 +16,18 @@ const PARAM_END = "<!--PARAMS_END-->";
 function stripParamBlock(text) {
   const start = text.indexOf(PARAM_START);
   const end = text.indexOf(PARAM_END);
+  let result = text;
   if (start !== -1 && end !== -1 && end > start) {
     let before = text.slice(0, start);
     let after = text.slice(end + PARAM_END.length);
     if (before.endsWith("\n")) before = before.slice(0, -1);
     if (after.startsWith("\n")) after = after.slice(1);
-    return before + after;
+    result = before + after;
   }
-  return text;
+  return result.replace(
+    /[ \t]*<xsl:param\b[^>]*?(?:\/>|>[\s\S]*?<\/xsl:param>)[ \t]*(?:\r?\n)?/g,
+    "",
+  );
 }
 
 


### PR DESCRIPTION
## Summary
- avoid duplication of `<xsl:param>` by cleaning up all parameter definitions when stripping the injected block

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868d58db1948329a721eba919764d77