### PR TITLE
Fix parameter file handling

### DIFF
--- a/backend/src/main.go
+++ b/backend/src/main.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -148,12 +149,15 @@ func main() {
 	r.POST("/transform", func(c *gin.Context) {
 		var req TransformRequest
 		if err := c.ShouldBindJSON(&req); err != nil {
+			log.Printf("bind request failed: %v (content-length=%d)", err, c.Request.ContentLength)
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
+		log.Printf("processing transform: xslt %d bytes, %d parameters", len(req.XSLT), len(req.Parameters))
 
 		tmpDir, err := ioutil.TempDir("", "xslt")
 		if err != nil {
+			log.Printf("temp dir creation failed: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "cannot create temp dir"})
 			return
 		}
@@ -164,11 +168,13 @@ func main() {
 		outputPath := filepath.Join(tmpDir, "result.xml")
 
 		if err := os.WriteFile(xsltPath, []byte(req.XSLT), 0644); err != nil {
+			log.Printf("write xslt failed: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "cannot write xslt"})
 			return
 		}
 
 		if err := os.WriteFile(inputPath, []byte("<root/>"), 0644); err != nil {
+			log.Printf("write input failed: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "cannot write input"})
 			return
 		}
@@ -180,8 +186,16 @@ func main() {
 			"-xsl:" + xsltPath,
 			"-o:" + outputPath,
 		}
+		idx := 0
 		for k, v := range req.Parameters {
-			cmdArgs = append(cmdArgs, k+"="+v)
+			paramFile := filepath.Join(tmpDir, fmt.Sprintf("param_%d", idx))
+			if err := os.WriteFile(paramFile, []byte(v), 0644); err != nil {
+				log.Printf("write parameter %s failed: %v", k, err)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "cannot write parameter"})
+				return
+			}
+			cmdArgs = append(cmdArgs, fmt.Sprintf("-param:%s=@%s", k, paramFile))
+			idx++
 		}
 
 		cmd := exec.Command("java", cmdArgs...)
@@ -196,22 +210,26 @@ func main() {
 		select {
 		case err := <-errChan:
 			if err != nil {
+				log.Printf("saxon error: %v; stderr: %s", err, stderr.String())
 				c.JSON(http.StatusBadRequest, gin.H{"error": stderr.String()})
 				return
 			}
 		case <-time.After(timeout):
 			cmd.Process.Kill()
+			log.Printf("saxon timeout after %v", timeout)
 			c.JSON(http.StatusRequestTimeout, gin.H{"error": "transformation timeout"})
 			return
 		}
 
 		result, err := os.ReadFile(outputPath)
 		if err != nil {
+			log.Printf("read result failed: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "cannot read result"})
 			return
 		}
 
 		duration := time.Since(start).Milliseconds()
+		log.Printf("transformation done in %dms", duration)
 		c.JSON(http.StatusOK, TransformResponse{Result: string(result), DurationMs: duration})
 	})
 


### PR DESCRIPTION
## Summary
- fix parameter handling with Saxon -param syntax

## Testing
- `gofmt -w backend/src/main.go`
- `(cd backend/src && go vet ./...)`


------
https://chatgpt.com/codex/tasks/task_e_687faa693478832998bd5501b94ec756