### PR TITLE
Fix XML parameter passing

### DIFF
--- a/backend/src/main.go
+++ b/backend/src/main.go
@@ -189,9 +189,19 @@ func main() {
 			"-xsl:"+xsltPath,
 			"-o:"+outputPath,
 		)
+
+		idx := 0
 		for k, v := range req.Parameters {
-			cmdArgs = append(cmdArgs, fmt.Sprintf("%s=%s", k, v))
+			paramFile := filepath.Join(tmpDir, fmt.Sprintf("param_%d", idx))
+			if err := os.WriteFile(paramFile, []byte(v), 0644); err != nil {
+				log.Printf("write parameter %s failed: %v", k, err)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "cannot write parameter"})
+				return
+			}
+			cmdArgs = append(cmdArgs, fmt.Sprintf("%s=@%s", k, paramFile))
+			idx++
 		}
+
 		if err := os.WriteFile(argsPath, []byte(strings.Join(cmdArgs, "\n")), 0644); err != nil {
 			log.Printf("write args file failed: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "cannot write args"})


### PR DESCRIPTION
## Summary
- ensure parameters containing XML are passed as files
- keep using a Java args file for the command

## Testing
- `make backend-build`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687fc28ee65c8329a6d4ed5b5651d206